### PR TITLE
Pass I2C address to PCT2075 initialization

### DIFF
--- a/examples/pct2075_test/pct2075_test.ino
+++ b/examples/pct2075_test/pct2075_test.ino
@@ -6,7 +6,7 @@
 
 Adafruit_PCT2075 PCT2075;
 
-uint8_t i2c_addr = PCT2075_ADDR_DEFAULT  // default address (see guide for others)
+uint8_t i2c_addr = PCT2075_I2CADDR_DEFAULT  // default address (see guide for others)
 
 void setup() {
   PCT2075 = Adafruit_PCT2075();

--- a/examples/pct2075_test/pct2075_test.ino
+++ b/examples/pct2075_test/pct2075_test.ino
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 Bryan Siepert for Adafruit Industries
+ine// SPDX-FileCopyrightText: 2019 Bryan Siepert for Adafruit Industries
 //
 // SPDX-License-Identifier: BSD
 
@@ -6,7 +6,7 @@
 
 Adafruit_PCT2075 PCT2075;
 
-uint8_t i2c_addr = 0x37  // default address (see guide for others)
+#define PCT2075_ADDR_DEFAULT 0x37  // default address (see guide for others)
 
 void setup() {
   PCT2075 = Adafruit_PCT2075();
@@ -16,7 +16,7 @@ void setup() {
   while (!Serial) { delay(1); }
   Serial.println("Adafruit PCT2075 Test");
 
-  if (!PCT2075.begin(i2c_addr)) {
+  if (!PCT2075.begin(PCT2075_ADDR_DEFAULT)) {
     Serial.println("Couldn't find PCT2075 chip");
     while (1);
   }

--- a/examples/pct2075_test/pct2075_test.ino
+++ b/examples/pct2075_test/pct2075_test.ino
@@ -1,4 +1,4 @@
-ine// SPDX-FileCopyrightText: 2019 Bryan Siepert for Adafruit Industries
+// SPDX-FileCopyrightText: 2019 Bryan Siepert for Adafruit Industries
 //
 // SPDX-License-Identifier: BSD
 

--- a/examples/pct2075_test/pct2075_test.ino
+++ b/examples/pct2075_test/pct2075_test.ino
@@ -6,7 +6,7 @@
 
 Adafruit_PCT2075 PCT2075;
 
-uint8_t i2c_addr = PCT2075_I2CADDR_DEFAULT  // default address (see guide for others)
+uint8_t i2c_addr = PCT2075_I2CADDR_DEFAULT;  // default address (see guide for others)
 
 void setup() {
   PCT2075 = Adafruit_PCT2075();

--- a/examples/pct2075_test/pct2075_test.ino
+++ b/examples/pct2075_test/pct2075_test.ino
@@ -1,7 +1,12 @@
+// SPDX-FileCopyrightText: 2019 Bryan Siepert for Adafruit Industries
+//
+// SPDX-License-Identifier: BSD
+
 #include <Adafruit_PCT2075.h>
 
-
 Adafruit_PCT2075 PCT2075;
+
+i2c = 0x37  // default address (see guide for others)
 
 void setup() {
   PCT2075 = Adafruit_PCT2075();
@@ -11,7 +16,7 @@ void setup() {
   while (!Serial) { delay(1); }
   Serial.println("Adafruit PCT2075 Test");
 
-  if (!PCT2075.begin()) {
+  if (!PCT2075.begin(i2c)) {
     Serial.println("Couldn't find PCT2075 chip");
     while (1);
   }

--- a/examples/pct2075_test/pct2075_test.ino
+++ b/examples/pct2075_test/pct2075_test.ino
@@ -6,7 +6,7 @@
 
 Adafruit_PCT2075 PCT2075;
 
-i2c = 0x37  // default address (see guide for others)
+uint8_t i2c_addr = 0x37  // default address (see guide for others)
 
 void setup() {
   PCT2075 = Adafruit_PCT2075();
@@ -16,7 +16,7 @@ void setup() {
   while (!Serial) { delay(1); }
   Serial.println("Adafruit PCT2075 Test");
 
-  if (!PCT2075.begin(i2c)) {
+  if (!PCT2075.begin(i2c_addr)) {
     Serial.println("Couldn't find PCT2075 chip");
     while (1);
   }

--- a/examples/pct2075_test/pct2075_test.ino
+++ b/examples/pct2075_test/pct2075_test.ino
@@ -6,7 +6,7 @@
 
 Adafruit_PCT2075 PCT2075;
 
-#define PCT2075_ADDR_DEFAULT 0x37  // default address (see guide for others)
+uint8_t i2c_addr = PCT2075_ADDR_DEFAULT  // default address (see guide for others)
 
 void setup() {
   PCT2075 = Adafruit_PCT2075();
@@ -16,7 +16,7 @@ void setup() {
   while (!Serial) { delay(1); }
   Serial.println("Adafruit PCT2075 Test");
 
-  if (!PCT2075.begin(PCT2075_ADDR_DEFAULT)) {
+  if (!PCT2075.begin(i2c_addr)) {
     Serial.println("Couldn't find PCT2075 chip");
     while (1);
   }

--- a/examples/pct2075_test/pct2075_test.ino
+++ b/examples/pct2075_test/pct2075_test.ino
@@ -9,7 +9,6 @@ Adafruit_PCT2075 PCT2075;
 uint8_t i2c_addr = PCT2075_I2CADDR_DEFAULT;  // default address (see guide for others)
 
 void setup() {
-  PCT2075 = Adafruit_PCT2075();
 
   Serial.begin(115200);
   // Wait until serial port is opened
@@ -20,7 +19,6 @@ void setup() {
     Serial.println("Couldn't find PCT2075 chip");
     while (1);
   }
-  
   Serial.println("Found PCT2075 chip");
 
 }


### PR DESCRIPTION
Changes to make i2c parameter explicit and add SPDX info
