### PR TITLE
Fix PCT2075 initialization with I2C address

### DIFF
--- a/examples/temp_alert_demo/temp_alert_demo.ino
+++ b/examples/temp_alert_demo/temp_alert_demo.ino
@@ -1,17 +1,21 @@
+// SPDX-FileCopyrightText: 2019 Bryan Siepert for Adafruit Industries
+//
+// SPDX-License-Identifier: BSD
+
 #include <Adafruit_PCT2075.h>
 
-
 Adafruit_PCT2075 pct;
+uint8_t i2c_addr = PCT2075_I2CADDR_DEFAULT;  // default address (see guide for others)
 
 void setup() {
-  pct = Adafruit_PCT2075();
+  // pct = Adafruit_PCT2075();
 
   Serial.begin(115200);
   // Wait until serial port is opened
   while (!Serial) { delay(1); }
   Serial.println("Adafruit PCT2075 Test");
 
-  if (!pct.begin()) {
+  if (!pct.begin(i2c_addr)) {
     Serial.println("Couldn't find PCT2075 chip");
     while (1);
   }


### PR DESCRIPTION
Change to make i2c address more explicit in examples per guide feedback. Add SPDX information